### PR TITLE
1.3 Adds user help modal

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Chrome extension designed to assist with troubleshooting and debugging web applications by providing a simple interface for common support tasks.
 
-## Version 1.2
+## Version 1.3
 
 ## Features
 
@@ -12,11 +12,12 @@ A Chrome extension designed to assist with troubleshooting and debugging web app
 - Choose which types of data to clear
 - Get instant feedback on success/failure
 
-### 2. Network Capture (HAR Files)
-- Record all network activity in the current tab
-- Save as industry-standard HAR (HTTP Archive) files
+### 2. Support Bundle Capture
+- Record system activity in the current tab
+- Save as industry-standard diagnostic files
 - Includes all requests, responses, headers, and timing information
 - Timestamped filenames for easy organization
+- Step-by-step guide for capturing effective support bundles
 
 ### 3. Screen Capture
 - **Screenshots**: Instantly capture the visible area of the current tab
@@ -24,8 +25,9 @@ A Chrome extension designed to assist with troubleshooting and debugging web app
   - Includes audio capture
   - Saves in WebM format for high quality with reasonable file size
   - Timestamped filenames
+  - Guided workflow for effective recordings
 
-### 4. Theme Options (New in v1.2)
+### 4. Theme Options
 - **Light Theme**: Standard light interface for bright environments
 - **Dark Theme**: Eye-friendly dark interface for low-light environments
 - **System Theme**: Automatically follows your operating system's theme preference
@@ -39,26 +41,29 @@ A Chrome extension designed to assist with troubleshooting and debugging web app
 2. Choose a time range from the dropdown
 3. Click "Clear Data"
 
-### Network Capture
-1. Navigate to the tab you want to capture
-2. Click "Start" to begin recording network activity
+### Support Bundle Capture
+1. Click "Start" to begin the guided capture process
+2. Follow the step-by-step instructions in the guide
 3. Perform the actions you want to capture
-4. Click "Stop & Download" to save the HAR file
-   - Note: HAR Capture is tab-specific. If you navigate away, you need to return to the same tab to stop the capture.
+4. Return to the extension tab when finished
+5. Click "Stop & Download" to save the support bundle
+6. Send the support bundle to your support technician
 
 ### Screen Capture
 - **For Screenshots**:
   1. Navigate to the tab you want to capture
   2. Click "Take Screenshot"
   3. Save the PNG file when prompted
+  4. Send the screenshot to your support technician when needed
 
 - **For Video Recording**:
-  1. Navigate to the tab where you want to begin recording
-  2. Click "Record Video"
+  1. Click "Record Video" to begin the guided recording process
+  2. Follow the step-by-step instructions in the guide
   3. Select which screen/window/tab to share when prompted
-  4. Navigate freely during recording
+  4. Record your workflow
   5. Click "Stop Recording" when finished (recording automatically stops after 5 minutes)
   6. Save the WebM file when prompted
+  7. Send the video to your support technician
 
 ### Theme Options
 - Click on one of the theme icons in the top-right corner:
@@ -70,8 +75,8 @@ A Chrome extension designed to assist with troubleshooting and debugging web app
 
 ## Technical Considerations
 
-- You can only have 1 HAR capture happening at a time
-- HAR Capture is tab-specific (if you start it in tab A, and go to tab B, you need to go back to A to stop and save)
+- You can only have 1 Support Bundle capture happening at a time
+- Support Bundle Capture is tab-specific (if you start it in tab A, and go to tab B, you need to go back to A to stop and save)
 - Video recordings are limited to 5 minutes to maintain reasonable file sizes
 - The extension requires specific Chrome permissions:
   - cookies, browsingData, storage, debugger, tabs, activeTab, downloads
@@ -86,28 +91,41 @@ A Chrome extension designed to assist with troubleshooting and debugging web app
 4. Click "Load unpacked" and select the extension directory
 5. The Browser Support Tool icon should appear in your toolbar
 
-
 ## Troubleshooting
 
-- If HAR capture fails, try refreshing the page and starting again
+- If Support Bundle capture fails, try refreshing the page and starting again
 - If video recording doesn't start, check if you denied screen sharing permissions
 - Clear browser data options require at least one checkbox to be selected
 - If the extension seems unresponsive, try reloading the extension from chrome://extensions/
 - If dark mode doesn't apply correctly, try toggling between themes or restarting the browser
 
-## Changelog for Version 1.2
+## Changelog
 
-### Added
-- Dark Mode/Theme Options
+### Version 1.3 (Current)
+- Added guided step-by-step modals for Support Bundle capture and Video Recording
+- Renamed "Network Capture" to "Support Bundle Capture" for better user experience
+- Added "Do not show again" option for guided help modals
+- Added explicit step for sending captures to support team in guides
+- Fixed bug where "do not show again" preference would prevent capture/recording from starting
+- Enhanced theme consistency across all screens including recording
+- Improved accessibility of modal components
+- General performance improvements and bug fixes
+
+### Version 1.2
+- Added Dark Mode/Theme Options
   - Added light theme (default)
   - Added dark theme for low-light environments
   - Added system theme that matches OS preference
   - Theme selection is saved between sessions
   - Theme applies to all extension pages including the recorder
-
-### Improved
 - Enhanced notification appearance
 - Smooth transitions between themes
 - Better visibility of UI elements in dark mode
 - Improved color contrast for better accessibility
-```
+
+### Version 1.1
+- Initial public release
+- Clear Browser Data functionality
+- Network Capture (HAR files)
+- Screenshot capture
+- Video recording

--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,8 @@
 {
   "manifest_version": 3,
   "name": "Browser Support Tool",
-  "version": "1.1",
-  "description": "Chrome Extension for clearing cookies and cache, capture screenshots, videos and HAR files for simple debugging and troubleshooting",
+  "version": "1.3",
+  "description": "Chrome Extension for clearing cookies and cache, capture screenshots, videos and support bundles for simple debugging and troubleshooting",
   "permissions": [
     "cookies",
     "browsingData",

--- a/popup.html
+++ b/popup.html
@@ -56,8 +56,8 @@
       </section>
 
       <section class="card" id="har-section">
-        <h2>Network Capture</h2>
-        <p>Capture network activity for troubleshooting.</p>
+        <h2>Support Bundle Capture</h2>
+        <p>Capture a bug in action to share with the support team!</p>
         <div class="buttons-container">
           <button id="startCapture" class="secondary-button">Start</button>
           <button id="stopCapture" class="secondary-button" disabled>Stop & Download</button>
@@ -88,6 +88,27 @@
       <!-- Footer remains, but notification moved under header -->
     </footer>
   </div>
+
+  <!-- Modal Component -->
+  <div id="modal-container" class="modal-container hidden">
+    <div class="modal">
+      <div class="modal-header">
+        <h2 id="modal-title">Guide</h2>
+        <button id="modal-close" class="modal-close-btn">&times;</button>
+      </div>
+      <div id="modal-content" class="modal-content">
+        <!-- Content will be dynamically set -->
+      </div>
+      <div class="modal-footer">
+        <div class="do-not-show-container">
+          <input type="checkbox" id="do-not-show-again">
+          <label for="do-not-show-again">Don't show this guide again</label>
+        </div>
+        <button id="modal-primary-btn" class="primary-button">Got it</button>
+      </div>
+    </div>
+  </div>
+
   <script src="popup.js"></script>
 </body>
 </html>

--- a/recorder.html
+++ b/recorder.html
@@ -5,23 +5,68 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Browser Support Tool - Recording</title>
   <style>
+    /* Theme variables - light mode defaults */
+    :root {
+      /* Core colors - Light theme */
+      --bg-color: #f1f3f4;
+      --card-bg: #ffffff;
+      --text-color: #202124;
+      --light-text: #5f6368;
+      --border-color: #dadce0;
+      --box-shadow: 0 1px 3px rgba(60, 64, 67, 0.12), 0 1px 2px rgba(60, 64, 67, 0.24);
+      
+      /* Brand colors - consistent across themes */
+      --primary-color: #1a73e8; /* Google blue */
+      --primary-hover: #1765cc; /* Darker blue */
+      --recording-color: #ea4335; /* Google red */
+      --recording-hover: #d33426; /* Darker red */
+      
+      /* Theme transition */
+      --transition-time: 0.3s;
+    }
+    
+    /* Dark theme overrides */
+    :root.dark-theme {
+      --bg-color: #202124;
+      --card-bg: #303134;
+      --text-color: #e8eaed;
+      --light-text: #9aa0a6;
+      --border-color: #5f6368;
+      --box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3), 0 1px 3px rgba(0, 0, 0, 0.4);
+      
+      /* Accent color adjustments */
+      --primary-color: #8ab4f8; /* Lighter blue */
+      --primary-hover: #aecbfa; /* Even lighter blue for hover */
+      --recording-color: #f28b82; /* Lighter red */
+      --recording-hover: #f6aea9; /* Even lighter red */
+    }
+    
+    /* Apply transitions for smooth theme switching */
+    * {
+      transition: background-color var(--transition-time) ease,
+                  color var(--transition-time) ease,
+                  border-color var(--transition-time) ease,
+                  box-shadow var(--transition-time) ease;
+    }
+
     body {
       font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-      background-color: #f1f3f4;
-      color: #202124;
+      background-color: var(--bg-color);
+      color: var(--text-color);
       text-align: center;
       padding: 20px;
+      margin: 0;
     }
     .recording-container {
       max-width: 600px;
       margin: 0 auto;
-      background-color: #ffffff;
+      background-color: var(--card-bg);
       border-radius: 8px;
       padding: 20px;
-      box-shadow: 0 1px 3px rgba(60, 64, 67, 0.12), 0 1px 2px rgba(60, 64, 67, 0.24);
+      box-shadow: var(--box-shadow);
     }
     h1 {
-      color: #1a73e8;
+      color: var(--primary-color);
       margin-bottom: 20px;
     }
     .status {
@@ -38,7 +83,7 @@
       display: inline-block;
       width: 16px;
       height: 16px;
-      background-color: #ea4335;
+      background-color: var(--recording-color);
       border-radius: 50%;
       margin-right: 8px;
       animation: pulse 1s infinite alternate;
@@ -47,10 +92,16 @@
       margin: 20px 0;
       text-align: left;
       padding: 15px;
-      background-color: #f8f9fa;
+      background-color: rgba(0, 0, 0, 0.03);
       border-radius: 4px;
       line-height: 1.5;
+      color: var(--text-color);
     }
+    
+    .dark-theme .instructions {
+      background-color: rgba(255, 255, 255, 0.05);
+    }
+    
     .buttons {
       margin-top: 30px;
     }
@@ -61,12 +112,16 @@
       cursor: pointer;
       font-weight: 600;
       font-size: 16px;
-      background-color: #ea4335;
+      background-color: var(--recording-color);
       color: white;
       transition: background-color 0.2s;
     }
     button:hover {
-      background-color: #d33426;
+      background-color: var(--recording-hover);
+    }
+    button:disabled {
+      opacity: 0.6;
+      cursor: not-allowed;
     }
     @keyframes pulse {
       0% { opacity: 0.6; }

--- a/recorder.js
+++ b/recorder.js
@@ -16,6 +16,9 @@ document.addEventListener('DOMContentLoaded', function() {
   // Set up button listener
   stopRecordingButton.addEventListener('click', stopRecording);
   
+  // Apply theme if saved
+  applyThemeFromStorage();
+  
   // Start recording on page load
   startRecording();
   
@@ -50,6 +53,20 @@ document.addEventListener('DOMContentLoaded', function() {
     }
   });
 });
+
+// Apply theme from local storage
+function applyThemeFromStorage() {
+  // Check if theme is stored in localStorage
+  const theme = localStorage.getItem('theme') || 'system';
+  
+  if (theme === 'dark') {
+    document.documentElement.classList.add('dark-theme');
+  } else if (theme === 'system') {
+    if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      document.documentElement.classList.add('dark-theme');
+    }
+  }
+}
 
 // Start video recording
 function startRecording() {

--- a/styles.css
+++ b/styles.css
@@ -365,3 +365,140 @@ button {
 footer {
   margin-top: 0.75rem;
 }
+
+/* Modal Styles */
+.modal-container {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+  opacity: 1;
+  transition: opacity 0.3s ease;
+}
+
+.modal-container.hidden {
+  opacity: 0;
+  pointer-events: none;
+}
+
+.modal {
+  background-color: var(--card-bg);
+  border-radius: var(--border-radius);
+  box-shadow: var(--box-shadow);
+  width: 90%;
+  max-width: 480px;
+  max-height: 90vh;
+  display: flex;
+  flex-direction: column;
+  transform: translateY(0);
+  transition: transform 0.3s ease;
+  overflow: hidden;
+}
+
+.modal-container.hidden .modal {
+  transform: translateY(20px);
+}
+
+.modal-header {
+  padding: 1rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.modal-header h2 {
+  margin: 0;
+  color: var(--text-color);
+}
+
+.modal-close-btn {
+  background: none;
+  border: none;
+  font-size: 1.5rem;
+  line-height: 1;
+  cursor: pointer;
+  color: var(--light-text);
+  padding: 0.25rem;
+  min-width: auto;
+}
+
+.modal-close-btn:hover {
+  color: var(--text-color);
+}
+
+.modal-content {
+  padding: 1rem;
+  overflow-y: auto;
+  flex-grow: 1;
+}
+
+.modal-content p {
+  margin-bottom: 0.75rem;
+  line-height: 1.5;
+}
+
+.modal-content .step {
+  display: flex;
+  margin-bottom: 1rem;
+  align-items: flex-start;
+}
+
+.step-number {
+  background-color: var(--primary-color);
+  color: white;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: bold;
+  flex-shrink: 0;
+  margin-right: 0.75rem;
+  margin-top: 0.25rem;
+}
+
+.step-content {
+  flex-grow: 1;
+}
+
+.step-content h3 {
+  margin-top: 0;
+  margin-bottom: 0.5rem;
+  font-size: 1rem;
+}
+
+.step-content p {
+  margin: 0;
+  color: var(--light-text);
+}
+
+.modal-footer {
+  padding: 1rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border-top: 1px solid var(--border-color);
+}
+
+.do-not-show-container {
+  display: flex;
+  align-items: center;
+}
+
+.do-not-show-container input {
+  margin-right: 0.5rem;
+}
+
+.do-not-show-container label {
+  font-size: 0.85rem;
+  color: var(--light-text);
+  cursor: pointer;
+}


### PR DESCRIPTION
### Version 1.3 (Current)
- Added guided step-by-step modals for Support Bundle capture and Video Recording
- Renamed "Network Capture" to "Support Bundle Capture" for better user experience
- Added "Do not show again" option for guided help modals
- Added explicit step for sending captures to support team in guides
- Fixed bug where "do not show again" preference would prevent capture/recording from starting
- Enhanced theme consistency across all screens including recording
- Improved accessibility of modal components
- General performance improvements and bug fixes